### PR TITLE
Add formatting for IP prefixes

### DIFF
--- a/nbcli/views/__init__.py
+++ b/nbcli/views/__init__.py
@@ -8,4 +8,5 @@ from nbcli.views.locations import DcimLocationsView             # noqa: F401
 from nbcli.views.sites import DcimSitesView                     # noqa: F401
 from nbcli.views.aggregates import IpamAggregatesView           # noqa: F401
 from nbcli.views.ip_addresses import IpamIpAddressesView        # noqa: F401
+from nbcli.views.ip_prefixes import IpamPrefixesView            # noqa: F401
 from nbcli.views.object_changes import ExtrasObjectChangesView  # noqa: F401

--- a/nbcli/views/ip_prefixes.py
+++ b/nbcli/views/ip_prefixes.py
@@ -1,0 +1,10 @@
+from nbcli.views.tools import BaseView
+
+class IpamPrefixesView(BaseView):
+
+    def table_view(self):
+
+        self.add_col('Prefix', self.get_attr('prefix'))
+        self.add_col('VLAN', self.get_attr('vlan'))
+        self.add_col('VLAN ID', self.get_attr('vlan.vid'))
+        self.add_col('Description', self.get_attr('description'))


### PR DESCRIPTION
A small change to make the IP Prefixes formatting more human readable.

Before:
```
Prefix
======
ID   IpamPrefixes
97   192.168.1.0/24
```

After:
```
Prefix
======
Prefix          VLAN          VLAN ID  Description
192.168.1.0/24  Example vlan  184      Example network of wonderful things
```